### PR TITLE
Tighten plaintext commitment

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -689,9 +689,13 @@ precomputation, while still allowing multiple plaintexts to generate the same sa
 We additionally include the Merkle root of a recent accepted Protocol Message when calculating this commitment. Which 
 root is selected **MUST** be stored alongside the ciphertext. By "recent", we strictly mean the following:
 
-1. Implementations **SHOULD** use the Merkle root of the most recent Protocol Message, if possible.
-2. If there are N accepted messages in the ledger, the selected Merkle root **MUST** be no more than log_2(N)^2 messages
-   old (rounded up to the nearest whole number).
+1. Clients are **RECOMMENDED** to use the Merkle root of the most recent Protocol Message.
+2. If there are N accepted messages in the ledger, the selected Merkle root **SHOULD** be no more than log_2(N)^2
+   messages old (rounded up to the nearest whole number). Public Key Directories **MUST NOT** reject messages newer than
+   this threshold on basis of staleness.
+3. To tolerate large transaction volumes in a short window of time, the chosen Merkle root **MUST** be at least in the 
+   most recent N/2 messages (for N currently accepted Protocol Messages). Public Key Directories **MAY** reject these
+   messages due to staleness, especially if the Directory isn't experiencing significant throughput.
 
 For example: When attempting to insert the 1,000,001th record, this means there are currently 1,000,000 accepted
 Protocol Messages stored in the Public Key Database. The 1,000,000th record is preferred (by rule 1 above).

--- a/Specification.md
+++ b/Specification.md
@@ -701,10 +701,10 @@ For example: When attempting to insert the 1,000,001th record, this means there 
 Protocol Messages stored in the Public Key Database. The 1,000,000th record is preferred (by rule 1 above).
 
 However, any message after 999,602 would be considered acceptable. Arithmetically, log_2(1,000,000) squared is 397.26.
-We round up to a tolerance window of 398. 1,000,000 minus 398 is 999,602. So any record's Merkle root in that range is
-acceptable to use.
+We round up to a tolerance window of 398. 1,000,000 minus 398 is 999,602. So any record's Merkle root corresponding to
+a message index in that range is acceptable to use.
 
-For the first message in a PKD, the Merkle root can be set to a sequence of 32 `0x00` bytes.
+For the first message in a PKD, the Merkle root **MUST** be set to a sequence of 32 `0x00` bytes.
 
 #### Message Attribute Plaintext Commitment Algorithm
 

--- a/Specification.md
+++ b/Specification.md
@@ -696,7 +696,7 @@ root is selected **MUST** be stored alongside the ciphertext. By "recent", we st
 For example: When attempting to insert the 1,000,001th record, this means there are currently 1,000,000 accepted
 Protocol Messages stored in the Public Key Database. The 1,000,000th record is preferred (by rule 1 above).
 
-However, any message after 999,602 would be considered acceptable. Arithmetically, log_2(1,000,000)^2 squared is 397.26.
+However, any message after 999,602 would be considered acceptable. Arithmetically, log_2(1,000,000) squared is 397.26.
 We round up to a tolerance window of 398. 1,000,000 minus 398 is 999,602. So any record's Merkle root in that range is
 acceptable to use.
 

--- a/test-code/tests/MessageEncryptorTest.php
+++ b/test-code/tests/MessageEncryptorTest.php
@@ -27,4 +27,22 @@ class MessageEncryptorTest extends TestCase
         $this->assertTrue($failed, 'Decryption should have failed');
     }
 
+    public function testWithReentRoot()
+    {
+        $key = random_bytes(32);
+        $recentRoot = random_bytes(32);
+        $crypt = new MessageEncryptor($key);
+        $cipher = $crypt->encrypt('foo', 'bar', $recentRoot);
+        $plain = $crypt->decrypt('foo', $cipher, $recentRoot);
+        $this->assertSame('bar', $plain);
+
+        try {
+            $crypt->decrypt('foo', $cipher);
+            $failed = false;
+        } catch (\Exception) {
+            $failed = true;
+        }
+        $this->assertTrue($failed, 'Decryption should have failed without recent root');
+    }
+
 }


### PR DESCRIPTION
We also include a "recent" Merkle root in this commitment value, and describe what "recent" means.