### PR TITLE
Stub out algorithm selection

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -1890,7 +1890,7 @@ separate specification exists for Ed25519. That is not a criticism of the algori
 The authors of this specification strongly recommend asking an applied cryptography expert develop these cryptographic
 components.
 
-The cryptography version used for the current specification is `1`.
+The cryptography version used for the current specification is [Version 1](#version-1).
 
 ### Protocol Message Encryption
 


### PR DESCRIPTION
This updates the specification text to make it easier for algorithm suites to be specified that use alternative cryptographic primitives.

For example, if someone (for whatever reason) wanted a CNSA 2.0 and/or FIPS-140 compatible alternative to v1, they could use a NIST SP800-108 KDF with ML-DSA-44 for signatures.

(I personally don't see any value in FIPS for this project, but stranger things have happened.)

See also: #52 (this satisfies an orthogonal concern)