### PR TITLE
This remark is outdated.

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -1967,10 +1967,6 @@ We also include a commitment of the plaintext, which is also covered by the ciph
 domain-separated HMAC to calculate a salt, which is then used to calculate an Argon2id KDF output of the plaintext.
 We use Argon2id to make brute-force attacks impractical.
 
-The Argon2id salt is deliberately **NOT** collision-resistant, such that multiple plaintexts can produce the same salt.
-The salt probability space (2^{48}) is large enough to not give an attacker any significant advantage with 
-precomputation, while still allowing multiple plaintexts to generate the same salt (birthday bound = 2^{24} attributes).
-
 #### Recent Merkle Root Included in Plaintext Commitments
 
 We additionally include the Merkle root of a recent accepted Protocol Message when calculating this commitment. Which 


### PR DESCRIPTION
After publishing this blog post, I updated the protocol to use 128-bit salts: https://soatok.blog/2024/11/21/key-transparency-and-the-right-to-be-forgotten/

The new 128-bit Argon2id salt is calculated from multiple inputs, including a recent Merkle root and the public randomness used for HKDF (for key splitting).

This remark in Security Considerations is vestigial.