### PR TITLE
Add TOTP / MFA for BurnDown by Instance Admins

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -1336,8 +1336,9 @@ Some authenticator apps do not support these parameters.
 
 #### TOTP Enrollment
 
-Clients **MUST** generate at least 192 bits of randomness (preferably 256), then encode this with base32 (RFC 4648).
-This will serve as the TOTP secret key.
+Clients **MUST** generate at least 192 bits of randomness (preferably 256). This will serve as the TOTP secret key.
+This secret value will be encoded with base32 ([RFC 4648, section 6](https://www.rfc-editor.org/rfc/rfc4648.html#section-6))
+when served to the end users (e.g., via a QR code).
 
 This secret must be shared with the Public Key Directory instance, [encrypted with HPKE like Protocol Messages](#encryption-of-protocol-messages).
 


### PR DESCRIPTION
Fixes #43 and tightens up the threat model a little bit.

We needed to consider a few trade-offs (one TOTP secret vs loose enforcement vs PKD needing to know who's an admin at all), and chose the simplest approach.